### PR TITLE
Add women-in-tech inviter

### DIFF
--- a/features/wit-invite.js
+++ b/features/wit-invite.js
@@ -1,0 +1,22 @@
+const WIT_ROLE_ID = "542091699447529492";
+
+const witInvite = {
+  handleMessage: ({ msg, user }) => {
+    if (
+      msg.channel.id === "541673256596537366" &&
+      msg.content.startsWith("!add") &&
+      msg.member.roles.has(WIT_ROLE_ID)
+    ) {
+      msg.mentions.users.forEach(user => {
+        msg.member.guild.member(user).addRole(WIT_ROLE_ID);
+        msg.channel.send(
+          `Added <@${user.id}> to <#${msg.channel.id}>! Welcome :)`
+        );
+      });
+    }
+  }
+};
+
+module.exports = {
+  default: witInvite
+};

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const qna = require("./features/qna").default;
 const jobs = require("./features/jobs").default;
 const autoban = require("./features/autoban").default;
 const commands = require("./features/commands").default;
+const witInvite = require("./features/wit-invite").default;
 
 const bot = new discord.Client();
 bot.login(process.env.DISCORD_HASH);
@@ -78,6 +79,7 @@ logger.add(channelLog(bot, "479862475047567361"));
 
 // reactiflux
 channelHandlers.addHandler("103882387330457600", jobs);
+channelHandlers.addHandler("541673256596537366", witInvite); // #women-in-tech
 channelHandlers.addHandler("106168778013822976", qna); // reactiflux-admin
 channelHandlers.addHandler("193117606629081089", qna); // #q&a
 


### PR DESCRIPTION
`!add @mention1 @mention2` should work. It's limited to people who have the role _and_ to the #women-in-tech channel, which is redundant but hey. It's also a little redundant that it's set up as a separate listener on that specific channel ID and also checks that the message came from that channel.